### PR TITLE
fix bugs of armor_tracker

### DIFF
--- a/armor_tracker/include/armor_tracker/tracker_node.hpp
+++ b/armor_tracker/include/armor_tracker/tracker_node.hpp
@@ -39,7 +39,7 @@ private:
 
   // The time when the last message was received
   rclcpp::Time last_time_;
-  double dt_;
+  int dt_;
 
   // Armor tracker
   double s2qxyz_, s2qyaw_, s2qr_;

--- a/armor_tracker/src/tracker.cpp
+++ b/armor_tracker/src/tracker.cpp
@@ -201,6 +201,7 @@ void Tracker::handleArmorJump(const Armor & current_armor)
     target_state(1) = 0;                   // vxc
     target_state(2) = p.y + r * sin(yaw);  // yc
     target_state(3) = 0;                   // vyc
+    target_state(4) = p.z;                 // xz
     target_state(5) = 0;                   // vza
     RCLCPP_ERROR(rclcpp::get_logger("armor_tracker"), "State wrong!");
   }


### PR DESCRIPTION
第一处，根据tracker_->lost_thres = static_cast<int>(lost_time_thres_ / dt_);判断，Tracker的属性lost_time_thres应该是int型
第二处，如果新测量值的yaw与状态target_state的yaw差别不大，在重置EKF时不会更新target_state的z坐标，不合理