### PR TITLE
fix bugs of armor_tracker

### DIFF
--- a/armor_tracker/include/armor_tracker/tracker.hpp
+++ b/armor_tracker/include/armor_tracker/tracker.hpp
@@ -46,7 +46,7 @@ public:
   ExtendedKalmanFilter ekf;
 
   int tracking_thres;  // frame
-  double lost_thres;   // second
+  int lost_thres;   // second
 
   Armor tracked_armor;
   std::string tracked_id;

--- a/armor_tracker/include/armor_tracker/tracker_node.hpp
+++ b/armor_tracker/include/armor_tracker/tracker_node.hpp
@@ -39,7 +39,7 @@ private:
 
   // The time when the last message was received
   rclcpp::Time last_time_;
-  double dt_;
+  int dt_;
 
   // Armor tracker
   double s2qxyz_, s2qyaw_, s2qr_;

--- a/armor_tracker/include/armor_tracker/tracker_node.hpp
+++ b/armor_tracker/include/armor_tracker/tracker_node.hpp
@@ -39,7 +39,7 @@ private:
 
   // The time when the last message was received
   rclcpp::Time last_time_;
-  int dt_;
+  double dt_;
 
   // Armor tracker
   double s2qxyz_, s2qyaw_, s2qr_;

--- a/armor_tracker/src/tracker.cpp
+++ b/armor_tracker/src/tracker.cpp
@@ -201,6 +201,7 @@ void Tracker::handleArmorJump(const Armor & current_armor)
     target_state(1) = 0;                   // vxc
     target_state(2) = p.y + r * sin(yaw);  // yc
     target_state(3) = 0;                   // vyc
+    target_state(4) = p.z;                 // xz
     target_state(5) = 0;                   // vza
     RCLCPP_ERROR(rclcpp::get_logger("armor_tracker"), "State wrong!");
   }


### PR DESCRIPTION
第一处，根据tracker_->lost_thres = static_cast<int>(lost_time_thres_ / dt_);判断，Tracker的属性lost_thres应该是int型
第二次，若新测量值的yaw与target_state的yaw差距不大时，但出现State Wrong，需要重置EKF时，不会重置target_state的z坐标，显然不合理